### PR TITLE
FIX: Change emotion library dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     }
   ],
   "name": "social-food-ui",
-  "version": "0.0.35",
+  "version": "0.0.36",
   "engines": {
     "node": "21.7.3"
   },
@@ -26,20 +26,6 @@
   "module": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": ["dist"],
-  "dependencies": {
-    "@emotion/react": "11.11.4",
-    "@emotion/styled": "11.11.5",
-    "@testing-library/jest-dom": "5.17.0",
-    "@testing-library/react": "13.4.0",
-    "@testing-library/user-event": "13.5.0",
-    "@types/jest": "27.5.2",
-    "@types/node": "20.11.0",
-    "@types/react": "18.2.74",
-    "@types/react-dom": "18.2.24",
-    "react": "18.2.0",
-    "react-dom": "18.2.0",
-    "typescript": "5.0.3"
-  },
   "overrides": {
     "@typescript-eslint/typescript-estree": "5.57.1",
     "fork-ts-checker-webpack-plugin": "6.5.3",
@@ -54,7 +40,25 @@
     "build:storybook": "storybook build",
     "build-storybook": "storybook build"
   },
+  "peerDependencies": {
+    "@emotion/react": "11.11.4",
+    "@emotion/styled": "11.11.5"
+  },
+  "dependencies": {
+    "@testing-library/jest-dom": "5.17.0",
+    "@testing-library/react": "13.4.0",
+    "@testing-library/user-event": "13.5.0",
+    "@types/jest": "27.5.2",
+    "@types/node": "20.11.0",
+    "@types/react": "18.2.74",
+    "@types/react-dom": "18.2.24",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "typescript": "5.0.3"
+  },
   "devDependencies": {
+    "@emotion/react": "11.11.4",
+    "@emotion/styled": "11.11.5",
     "@chromatic-com/storybook": "1.3.3",
     "@storybook/addon-essentials": "8.0.8",
     "@storybook/addon-interactions": "8.0.8",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -19,6 +19,9 @@ export default defineConfig({
             name: 'social-food-ui',
             fileName: 'index',
             formats: ['es', 'cjs']
+        },
+        rollupOptions: {
+            external: ['@emotion/react', '@emotion/styled']
         }
     }
 });


### PR DESCRIPTION
새로운 오류 봉착
TypeError: Cannot read properties of null (reading 'useContext')
검색해보니, 스타일드컴포넌트(emotion)을 라이브러리에서 사용한 후 번들링해버리고 
사용처에서도 스타일드컴포넌트를 번들링 된 채로 읽어서 나는 오류로 이해함. 
해걸책으로는, 스타일드컴포넌트를 필수 의존으로 명시하지 않고, 번들링할 때도 제외하는 것으로 에러 수정이 가능하다고 하여 시도