### PR TITLE
FIX: Remove mixin in styled component

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     }
   ],
   "name": "social-food-ui",
-  "version": "0.0.38",
+  "version": "0.0.39",
   "engines": {
     "node": "21.7.3"
   },

--- a/src/packages/Typography/Admin/useAdminTypography.tsx
+++ b/src/packages/Typography/Admin/useAdminTypography.tsx
@@ -97,18 +97,13 @@ interface ComponentProps {
   readonly weight: AdminFontWeightsType;
 }
 
-const HeadComponent = styled.h2<ComponentProps>`
-    ${fontStyle};
-    font-family: Pretendard, -apple-system, BlinkMacSystemFont, system-ui, Roboto, "Helvetica Neue", "Segoe UI", "Apple SD Gothic Neo", "Noto Sans KR", "Malgun Gothic", "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", sans-serif;
-    
-    margin: 0;
-    font-weight: ${(props) => (props.weight)};
-    font-size: ${(props) => (props.size)};
-    color: ${(props) => (colorsPalette[props.color])};
+const HeadComponent = styled.h2`
+  font-family: Pretendard, -apple-system, BlinkMacSystemFont, system-ui, Roboto, "Helvetica Neue", "Segoe UI", "Apple SD Gothic Neo", "Noto Sans KR", "Malgun Gothic", "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", sans-serif;
+  color: #a00;
+  margin: 0;
 `;
 
 const ParagraphComponent = styled.p<ComponentProps>`
-    ${fontStyle};
     font-family: Pretendard, -apple-system, BlinkMacSystemFont, system-ui, Roboto, "Helvetica Neue", "Segoe UI", "Apple SD Gothic Neo", "Noto Sans KR", "Malgun Gothic", "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", sans-serif;
     
     margin: 0;


### PR DESCRIPTION
TypeError: G.h2 is not a function

에러가 해당 함수 export를 제대로 못해서 한줄알았는데,
다시 보니 styled component에서 
```

const HeadComponent = styled.h2<ComponentProps>`
    ${fontStyle};
    font-family: Pretendard, -apple-system, BlinkMacSystemFont, system-ui, Roboto, "Helvetica Neue", "Segoe UI", "Apple SD Gothic Neo", "Noto Sans KR", "Malgun Gothic", "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", sans-serif;
    
    margin: 0;
    font-weight: ${(props) => (props.weight)};
    font-size: ${(props) => (props.size)};
    color: ${(props) => (colorsPalette[props.color])};
`;
```
styled.h2 이렇게 사용하는 거 자체가 오류인듯하다.
함수처럼 props를 받는거 자체가 문제인지 확인해보기위해 props 관련 모두 제거해봄 