### PR TITLE
FIX: Remove tcs-alias to script

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     }
   ],
   "name": "social-food-ui",
-  "version": "0.0.42",
+  "version": "0.0.43",
   "engines": {
     "node": "21.7.3"
   },
@@ -34,7 +34,7 @@
     "postcss": "8.4.5"
   },
   "scripts": {
-    "prepare": "rm -rf dist && mkdir dist && tsc && rm -rf ./dist/stories && cp -r ./public/assets ./dist && tsc-alias",
+    "prepare": "rm -rf dist && mkdir dist && tsc && rm -rf ./dist/stories && cp -r ./public/assets ./dist",
     "storybook": "storybook dev -p 6006",
     "build:storybook": "storybook build",
     "build-storybook": "storybook build"


### PR DESCRIPTION
tcs-alias에서 에러가 나서 배포가 안되는 상황.
스토리북 내에서만 사용하기 때문에 배포 후에는 필요 없을 것 같아서 삭제